### PR TITLE
modified the mesh_core.h and mesh_core.cpp

### DIFF
--- a/utils/cython/mesh_core.cpp
+++ b/utils/cython/mesh_core.cpp
@@ -96,7 +96,8 @@ void _get_normal(float *ver_normal, float *vertices, int *triangles, int nver, i
     float v1x, v1y, v1z, v2x, v2y, v2z;
 
     // get tri_normal
-    float tri_normal[3 * ntri];
+    std::vector<float> tri_normal_vector(3 * ntri);
+    float* tri_normal = tri_normal_vector.data();
     for (int i = 0; i < ntri; i++) {
         tri_p0_ind = triangles[3 * i];
         tri_p1_ind = triangles[3 * i + 1];

--- a/utils/cython/mesh_core.h
+++ b/utils/cython/mesh_core.h
@@ -12,6 +12,7 @@ Modified by cleardusk (https://github.com/cleardusk)
 #include <string>
 #include <iostream>
 #include <fstream>
+#include <vector>
 
 using namespace std;
 


### PR DESCRIPTION
Some C++ compiler assume 
type array[type size_t] not legal if size_t is not a constant.

modified it with C++ <vector> container
and 
 python3 setup.py build_ext -i
would no longer give error