### PR TITLE
Fix orientation of transform to image coordinate system

### DIFF
--- a/utils/ddfa.py
+++ b/utils/ddfa.py
@@ -43,17 +43,14 @@ def reconstruct_vertex(param, whitening=True, dense=False, transform=True):
 
     if dense:
         vertex = p @ (u + w_shp @ alpha_shp + w_exp @ alpha_exp).reshape(3, -1, order='F') + offset
-
-        if transform:
-            # transform to image coordinate space
-            vertex[1, :] = std_size + 1 - vertex[1, :]
     else:
         """For 68 pts"""
         vertex = p @ (u_base + w_shp_base @ alpha_shp + w_exp_base @ alpha_exp).reshape(3, -1, order='F') + offset
 
-        if transform:
-            # transform to image coordinate space
-            vertex[1, :] = std_size + 1 - vertex[1, :]
+    if transform:
+        # transform to image coordinate space (z pointing away from camera)
+        vertex[1, :] = std_size + 1 - vertex[1, :]
+        vertex[2, :] *= -1  # ensuring rhs coordinate system
 
     return vertex
 

--- a/utils/inference.py
+++ b/utils/inference.py
@@ -212,7 +212,7 @@ def write_obj_with_colors(obj_name, vertices, triangles, colors):
     with open(obj_name, 'w') as f:
         # write vertices & colors
         for i in range(vertices.shape[1]):
-            s = 'v {:.4f} {:.4f} {:.4f} {} {} {}\n'.format(vertices[1, i], vertices[0, i], vertices[2, i], colors[i, 2],
+            s = 'v {:.4f} {:.4f} {:.4f} {} {} {}\n'.format(vertices[0, i], vertices[1, i], vertices[2, i], colors[i, 2],
                                                colors[i, 1], colors[i, 0])
             f.write(s)
 


### PR DESCRIPTION
- Orientation of coordinate system was lhs for image coord system
while it was rhs in the world coordinate system.
- `write_obj_with_colors` swapped the x and y coordinates
- with new implementation ply and obj files are consistent and with
correct handedness

Closes https://github.com/cleardusk/3DDFA/issues/138